### PR TITLE
Correct eth port number of AS6700-32X

### DIFF
--- a/arch/powerpc/boot/dts/powerpc-as6700-32x-r0.dts
+++ b/arch/powerpc/boot/dts/powerpc-as6700-32x-r0.dts
@@ -42,10 +42,9 @@
 	interrupt-parent = <&mpic>;
 
 	aliases {
-        ethernet0 = &enet0;
+        ethernet0 = &enet3;
         ethernet2 = &enet2;
-        ethernet3 = &enet3;
-		phy_sgmii_2 = &phy_sgmii_2;
+        phy_sgmii_2 = &phy_sgmii_2;
         phy_sgmii_1e = &phy_sgmii_1e;
         phy_sgmii_1 = &phy_sgmii_1;
 	};


### PR DESCRIPTION
Correct device tree of as6700-32x to enable ma1 interface
