### PR TITLE
Enabled CONFIG_TUN and CONFIG_VETH

### DIFF
--- a/arch/powerpc/configs/onl_e500mc_defconfig
+++ b/arch/powerpc/configs/onl_e500mc_defconfig
@@ -1069,7 +1069,7 @@ CONFIG_NET_CORE=y
 # CONFIG_DUMMY is not set
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_FC is not set
-# CONFIG_MII is not set
+CONFIG_MII=y
 # CONFIG_NET_TEAM is not set
 # CONFIG_MACVLAN is not set
 # CONFIG_VXLAN is not set
@@ -1077,8 +1077,8 @@ CONFIG_NET_CORE=y
 # CONFIG_NETPOLL is not set
 # CONFIG_NET_POLL_CONTROLLER is not set
 # CONFIG_RIONET is not set
-# CONFIG_TUN is not set
-# CONFIG_VETH is not set
+CONFIG_TUN=y
+CONFIG_VETH=y
 # CONFIG_ARCNET is not set
 
 #


### PR DESCRIPTION
Needed for orc -- probably should be enabled anyway.

Also enabled CONFIG_MII to be in sync with the linux-3.9.6 kernel config.